### PR TITLE
f:link.page pageUid expects uid

### DIFF
--- a/_snippets/fluid/vhs/manually-rendering-breadcrumb-navigation-using-VHS-BreadCrumbViewHelper.md
+++ b/_snippets/fluid/vhs/manually-rendering-breadcrumb-navigation-using-VHS-BreadCrumbViewHelper.md
@@ -26,7 +26,7 @@ author: Rafał Brzeski
         <f:for each="{menu}" as="menuItem">
             <li class="list-inline-item {menuItem.class}">
                 <f:link.page
-                  pageUid="{menuItem.link}">
+                  pageUid="{menuItem.uid}">
                     {menuItem.title}
                 </f:link.page>
             </li>


### PR DESCRIPTION
menuItem.link is an actual link/slug (at least on 9lts) and f:link.page pageUid parameter expects page uid as an integer. Here's a simple fix.